### PR TITLE
#GET /user/ returns recent_searches.

### DIFF
--- a/api/controllers/apoController.js
+++ b/api/controllers/apoController.js
@@ -26,7 +26,7 @@ exports.read_pill = function(req, res) {
     if(req.headers.userid != null){
         User.findOne({'userID' : req.headers.userid},function(err,user_data){
             if(err){throw err;}
-            user_data.increment_query();
+            user_data.add_recent_search(req.params.pillID);
         });
     }
     //Search for pills

--- a/api/models/apoModel.js
+++ b/api/models/apoModel.js
@@ -40,7 +40,12 @@ var UserSchema = new Schema({
     recent_search: [Number]
 })
 
-UserSchema.methods.increment_query = function(callback){
+/**
+ * @param {Number} pillID The pill ID to add to the front of the list of recent searches
+ * @param callback
+ */
+UserSchema.methods.add_recent_search = function(pillID,callback){
+    this.recent_search.unshift(pillID);
     this.search_count ++;
     this.save(callback);
 }

--- a/test/user_test.js
+++ b/test/user_test.js
@@ -59,7 +59,7 @@ describe('User_v1 - Single and Duplicate Post Checks', function () {
 });
 
 // Requesting an existing user should return user's recent searches
-describe('User_v1 - /user/ Misc functionality',function(){
+describe('User_v1 - /user/ recent search functionality',function(){
     //Create user with fresh data after each test
     beforeEach(function(done){
         var user_with_searches = new Users(test_data.user_with_searches);
@@ -110,6 +110,17 @@ describe('User_v1 - /user/ Misc functionality',function(){
                 if(err){throw err;}
                 expect(user.search_count).to.be.a('number');
                 expect(user.search_count).to.equal(1);
+                done();
+            });
+        });
+    });
+
+    it('should have pillID of recently searched pill in recent_search array',function(done){
+        request(app).get(v1+'/pill/'+test_data.single_pill.pillID).set('userid',test_data.user.userID).end(function(err,res){
+            expect(res.statusCode).to.equal(200);
+            Users.findOne({'userID':test_data.user.userID},function(err,user){
+                if(err){throw err;}
+                expect(user.recent_search).to.contain(test_data.single_pill.pillID);
                 done();
             });
         });


### PR DESCRIPTION
Searching a pill and adding a userID as a header parameter will add the pillID to the list of recent searches for that user. Requesting a /user/ with userID as a parameter will return a list of pillID's for that user.